### PR TITLE
Zero NaN points in eucl. grid

### DIFF
--- a/src/euclidean_grid.cpp
+++ b/src/euclidean_grid.cpp
@@ -20,6 +20,7 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/kdtree.h>
 #include <pcl/segmentation/extract_clusters.h>
+#include <pcl/common/point_tests.h>
 // ROS package
 #include "lidar_cluster/marker.hpp"
 // Benchmarking
@@ -278,6 +279,15 @@ private:
     {
       // Print the length of the pointcloud
       RCLCPP_INFO_STREAM(this->get_logger(), "PointCloud in: " << original_size << " reduced size before cluster: " << cloud->width * cloud->height);
+    }
+
+    // if any point in the pointcloud is not a proper number, modify that value to zero
+    for (auto &point : cloud_xyz->points) {
+        if (!pcl::isFinite(point)) {
+            point.x = 0.0;
+            point.y = 0.0;
+            point.z = 0.0;
+        }
     }
 
     // Create voxel grid and project to 2D


### PR DESCRIPTION
Fixing #9 

NaN points in the cloud caused crashes, this PR zeroes points that are NaN in the cloud. 

There's something still off with the merged cloud data that this behaviour happens with, as qhull errors now pop up occasionally, but they don't crash, so whatever for now. Might require further investigation.

